### PR TITLE
Fix license deactivation on aborted builds & Xamarin.Mac support

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -11,15 +11,10 @@ workflows:
     - path::./:
         title: Login
         inputs:
-        - bitrise_repository: $BITRISE_APP_SLUG
-        - xamarin_action: login
+        - build_slug: $BITRISE_BUILD_SLUG
         - xamarin_ios_license: "yes"
         - xamarin_android_license: "yes"
-    - path::./:
-        title: Logout
-        inputs:
-        - bitrise_repository: $BITRISE_APP_SLUG
-        - xamarin_action: logout
+        - xamarin_mac_license: "no"
 
   # ----------------------------------------------------------------
   # --- workflows to Share this step into a Step Library
@@ -28,7 +23,7 @@ workflows:
       # if you want to share this step into a StepLib
       - MY_STEPLIB_REPO_FORK_GIT_URL:
       - STEP_ID_IN_STEPLIB: xamarin-user-management
-      - STEP_GIT_VERION_TAG_TO_SHARE: 0.9.0
+      - STEP_GIT_VERION_TAG_TO_SHARE: 1.0.0
       - STEP_GIT_CLONE_URL: https://github.com/bitrise-steplib/steps-xamarin-user-management.git
     description: |-
       If this is the first time you try to share a Step you should

--- a/step.rb
+++ b/step.rb
@@ -3,39 +3,54 @@ require 'json'
 require 'pathname'
 require 'fileutils'
 
-repository = ENV['bitrise_repository']
-action = ENV['xamarin_action']
+ios_license_path = "$HOME/Library/MonoTouch/License.v2"
+android_license_path = "$HOME/Library/MonoAndroid/License"
+mac_license_path = "$HOME/Library/Xamarin.Mac/License.v2"
+
+build_slug = ENV['build_slug']
 get_ios_license = ENV['xamarin_ios_license'].eql?("yes") ? true : false
 get_android_license = ENV['xamarin_android_license'].eql?("yes") ? true : false
+get_mac_license = ENV['xamarin_mac_license'].eql?("yes") ? true : false
+
+puts "\e[34mGathering Xamarin License requirements"
+licenses = []
+if get_ios_license && File.exists?(ios_license_path)
+  get_ios_license = false
+  puts "Skipping Xamarin.iOS license downloading. Already downloaded."
+elsif get_ios_license
+  licenses << "Xamarin.iOS"
+end
+if get_android_license && File.exists?(android_license_path)
+  android_license_path = false
+  puts "Skipping Xamarin.Android license downloading. Already downloaded."
+elsif get_android_license
+  licenses << "Xamarin.Android"
+end
+if get_mac_license && File.exists?(mac_license_path)
+  mac_license_path = false
+  puts "Skipping Xamarin.Mac license downloading. Already downloaded."
+elsif get_mac_license
+  licenses << "Xamarin.Mac"
+end
+
+if licenses.count > 0
+  puts "Downloading licenses: #{licenses.join(', ')}"
+end
 
 # Get machine information
 machine_data = `/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/bin/mtouch --datafile`
 
-# Get URL for action
-url = nil
-case action
-when "login"
-  url = 'http://xamarin.bitrise.io/activate'
-when "logout"
-  url = 'http://xamarin.bitrise.io/deactivate'
-else
-  puts "\e[31mUndefined action found\e[0m"
-  exit 1
-end
-
-unless url
-  puts "\e[31mNo user management URL found\e[0m"
-  exit 1
-end
+url = 'http://xamarin.bitrise.io/add_machine'
 
 uri = URI.parse(url)
 http = Net::HTTP.new(uri.host,uri.port)
 req = Net::HTTP::Post.new(uri.path)
 body = {
-  :slug => repository,
+  :build_slug => build_slug,
   :device => machine_data,
   :ios_license => get_ios_license,
-  :android_license => get_android_license
+  :android_license => get_android_license,
+  :mac_license => get_mac_license
 }.to_json
 
 response = http.request(req, body)
@@ -43,70 +58,49 @@ body = JSON.parse(response.body)
 
 if body['success'] == false
   puts "\e[31m#{body['error']}\e[0m"
-
-  if action.eql? "logout"
-    puts "To manually remove your Xamarin license associated with this machine go to https://store.xamarin.com/account/my/subscription/computers"
-  end
   exit 1
 end
 
-case action
-when "login"
-  if body['allowedMachines'] != 0 && body['usedMachines'] != 0
-    puts "Machine usage: #{body['usedMachines']}/#{body['allowedMachines']}"
-  end
+puts ""
+puts "\e[32mSuccessfully logged in to Xamarin"
 
-  if get_ios_license
-    ios_license_path = "$HOME/Library/MonoTouch/License.v2"
+if get_ios_license
+  FileUtils.mkdir_p(Pathname.new(ios_license_path).dirname)
+  `echo "#{body['ios']}" | base64 --decode > "#{ios_license_path}"`
+  puts "  \e[32mXamarin.iOS license file updated\e[0m (usage: #{body['ios_used_machines']}/#{body['ios_allowed_machines']})"
+end
 
-    if File.exists?(ios_license_path)
-      puts "\e[31mFailed to update iOS license. License already exists at path\e[0m"
-      exit 1
-    else
-      FileUtils.mkdir_p(Pathname.new(ios_license_path).dirname)
-      `echo "#{body['ios']}" | base64 --decode > "#{ios_license_path}"`
-      puts "Xamarin.iOS license file updated"
-    end
-  end
+if get_android_license
+  FileUtils.mkdir_p(Pathname.new(android_license_path).dirname)
+  `echo "#{body['android']}" | base64 --decode > "#{android_license_path}"`
 
-  if get_android_license
-    android_license_path = "$HOME/Library/MonoAndroid/License"
+  puts "  \e[32mXamarin.Android license file updated\e[0m (usage: #{body['android_used_machines']}/#{body['android_allowed_machines']})"
+end
 
-    if File.exists?(android_license_path)
-      puts "\e[31mFailed to update Android license. License already exists at path\e[0m"
-      exit 1
-    else
-      FileUtils.mkdir_p(Pathname.new(android_license_path).dirname)
-      `echo "#{body['android']}" | base64 --decode > "#{android_license_path}"`
+if get_mac_license
+  FileUtils.mkdir_p(Pathname.new(mac_license_path).dirname)
+  `echo "#{body['mac']}" | base64 --decode > "#{mac_license_path}"`
 
-      puts "Xamarin.Android license file updated"
-    end
-  end
+  puts "  \e[32mXamarin.Mac license file updated\e[0m (usage: #{body['mac_used_machines']}/#{body['mac_allowed_machines']})"
+end
 
-  puts ""
-  puts "\e[32mSuccessfully logged in to Xamarin"
+# Get components
+puts ""
+puts "\e[34mUpdating Xamarin Components Credentials\e[0m"
 
-  # Get components
-  puts ""
-  puts "Updating Xamarin Components Credentials"
+uri = URI.parse("http://xamarin.bitrise.io/components")
+http = Net::HTTP.new(uri.host,uri.port)
+req = Net::HTTP::Post.new(uri.path)
+body = {
+  :build_slug => build_slug
+}.to_json
 
-  uri = URI.parse("http://xamarin.bitrise.io/components")
-  http = Net::HTTP.new(uri.host,uri.port)
-  req = Net::HTTP::Post.new(uri.path)
-  body = {
-    :slug => repository
-  }.to_json
+response = http.request(req, body)
+body = JSON.parse(response.body)
 
-  response = http.request(req, body)
-  body = JSON.parse(response.body)
-
-  if body['success'] == false
-    puts "\e[31mFailed to update Xamarin Components Credentials\e[0m"
-  else
-    `echo "#{body['credential']}" | base64 --decode > "$HOME/.xamarin-credentials"`
-    puts "\e[32mUpdated Xamarin Components Credentials\e[0m"
-  end
-when "logout"
-  puts ""
-  puts "\e[32mSuccessfully logged out from Xamarin"
+if body['success'] == false
+  puts "\e[31mFailed to update Xamarin Components Credentials\e[0m"
+else
+  `echo "#{body['credential']}" | base64 --decode > "$HOME/.xamarin-credentials"`
+  puts "  \e[32mUpdated Xamarin Components Credentials\e[0m"
 end

--- a/step.sh
+++ b/step.sh
@@ -4,13 +4,8 @@ set -e
 
 THIS_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-if [ -z "$bitrise_repository" ]; then
-	printf "\e[31mbitrise_repository variable not set\e[0m\n"
-	exit 1
-fi
-
-if [ -z "$xamarin_action" ]; then
-	printf "\e[31mxamarin_action variable not set\e[0m\n"
+if [ -z "$build_slug" ]; then
+	printf "\e[build_slug variable not set\e[0m\n"
 	exit 1
 fi
 
@@ -22,6 +17,10 @@ fi
 if [ -z "$xamarin_android_license" ]; then
 	printf "\e[31mxamarin_android_license variable not set\e[0m\n"
 	exit 1
+fi
+
+if [ -z "$xamarin_mac_license" ]; then
+	export xamarin_mac_license="no"
 fi
 
 ruby "${THIS_SCRIPT_DIR}/step.rb"

--- a/step.yml
+++ b/step.yml
@@ -1,8 +1,7 @@
 title: "Xamarin User Management"
-summary: This step helps you authenticate your user with Xamarin.
+summary: This step helps you authenticate your user with Xamarin and to download your Xamarin liceses.
 description: |-
-  This step helps you authenticate your user with Xamarin and to download your Xamarin license file.
-  You can also use this to logout the user from the machine.
+  This step helps you authenticate your user with Xamarin and to download your Xamarin licenses.
 website: https://github.com/bitrise-steplib/steps-xamarin-user-management
 source_code_url: https://github.com/bitrise-steplib/steps-xamarin-user-management
 support_url: https://github.com/bitrise-steplib/steps-xamarin-user-management/issues
@@ -15,26 +14,18 @@ is_requires_admin_user: false
 is_always_run: true
 is_skippable: false
 inputs:
-  - xamarin_action: login
+  - build_slug: $BITRISE_BUILD_SLUG
     opts:
-      title: Xamarin action to run
-      value_options:
-        - login
-        - logout
-      is_required: true
-      is_expand: true
-  - bitrise_repository: $BITRISE_APP_SLUG
-    opts:
-      title: Bitrise repository slug
+      title: Bitrise build slug
       description: |
-        Bitrise repository slug
+        Bitrise build slug
       is_required: true
       is_expand: true
   - xamarin_ios_license: "yes"
     opts:
       title: Xamarin.iOS License
       description: |
-        Set true if you want to download the Xamarin.iOS license file
+        Set to yes if you want to download the Xamarin.iOS license file
       value_options:
           - "yes"
           - "no"
@@ -44,7 +35,17 @@ inputs:
     opts:
       title: Xamarin.Android License
       description: |
-        Set true if you want to download the Xamarin.Android license file
+        Set to yes if you want to download the Xamarin.Android license file
+      value_options:
+          - "yes"
+          - "no"
+      is_required: true
+      is_expand: true
+  - xamarin_mac_license: "no"
+    opts:
+      title: Xamarin.Mac License
+      description: |
+        Set to yes if you want to download the Xamarin.Mac license file
       value_options:
           - "yes"
           - "no"


### PR DESCRIPTION
machine usage information
logging improvements
Xamarin.Mac support
Skipping licenses if they are already installed
Using build slug instead of repository slug
